### PR TITLE
fix: createNewAccount always non-hardened derivation

### DIFF
--- a/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
+++ b/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
@@ -155,13 +155,7 @@ public class BIP32Keystore: AbstractKeystore {
         guard let newAddress = Utilities.publicToAddress(newNode.publicKey) else {
             throw AbstractKeystoreError.keyDerivationError
         }
-        let prefixPath = self.rootPrefix
-        var newPath: String
-        if newNode.isHardened {
-            newPath = prefixPath + "/" + String(newNode.index % HDNode.hardenedIndexPrefix) + "'"
-        } else {
-            newPath = prefixPath + "/" + String(newNode.index)
-        }
+        let newPath = rootPrefix + "/" + String(newNode.index)
         addressStorage.add(address: newAddress, for: newPath)
     }
 


### PR DESCRIPTION
A small improvement. Noticed that this function never uses hardened derivation as on line 152 you can see that `hardened: false` is being set.